### PR TITLE
Update API client to use 32 max connections

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Add this dependency to your project's POM:
 <dependency>
   <groupId>com.snap.business.sdk</groupId>
   <artifactId>capi-java</artifactId>
-  <version>1.1.4</version>
+  <version>1.1.5</version>
   <scope>compile</scope>
 </dependency>
 ```
@@ -35,7 +35,7 @@ Add this dependency to your project's build file:
   }
 
   dependencies {
-     implementation "com.snap.business.sdk:capi-java:1.1.4"
+     implementation "com.snap.business.sdk:capi-java:1.1.5"
   }
 ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <artifactId>capi-java</artifactId>
     <packaging>jar</packaging>
     <name>capi-java</name>
-    <version>1.1.4</version>
+    <version>1.1.5</version>
     <url>https://github.com/openapitools/openapi-generator</url>
     <description>OpenAPI Java</description>
     <scm>

--- a/src/main/java/com/snap/business/sdk/util/CapiConstants.java
+++ b/src/main/java/com/snap/business/sdk/util/CapiConstants.java
@@ -2,7 +2,7 @@ package com.snap.business.sdk.util;
 
 public class CapiConstants {
     public final static String SDK_LANGUAGE = "java";
-    public final static String SDK_VERSION = "1.1.4";
+    public final static String SDK_VERSION = "1.1.5";
     public final static String API_VERSION = "v2";
     public final static String PROD_URL = "https://tr.snapchat.com/" + API_VERSION;
     public final static String STAGING_URL = "https://tr-shadow.snapchat.com/" + API_VERSION;


### PR DESCRIPTION
Some clients have hardware limitations that might be causing SocketTimeoutException with 64 max connections. Initialize client to use 32 max connections.